### PR TITLE
Feature/#4 recommend recipe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ dependencies {
     //testContainer
     testImplementation 'org.testcontainers:spock:1.18.3'
     testImplementation "org.testcontainers:mysql:1.18.3"
+
+    //mockWebServer
+    testImplementation('com.squareup.okhttp3:okhttp:4.10.0')
+    testImplementation('com.squareup.okhttp3:mockwebserver:4.10.0')
 }
 
 tasks.named('test') {

--- a/src/main/java/com/yoons/managediet/BaseTimeEntity.java
+++ b/src/main/java/com/yoons/managediet/BaseTimeEntity.java
@@ -5,9 +5,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.Column;
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Getter

--- a/src/main/java/com/yoons/managediet/BaseTimeEntity.java
+++ b/src/main/java/com/yoons/managediet/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.yoons.managediet;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/yoons/managediet/ManageDietApplication.java
+++ b/src/main/java/com/yoons/managediet/ManageDietApplication.java
@@ -3,13 +3,14 @@ package com.yoons.managediet;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableJpaAuditing
 public class ManageDietApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(ManageDietApplication.class, args);
     }
-
 }

--- a/src/main/java/com/yoons/managediet/api/dto/RawDto.java
+++ b/src/main/java/com/yoons/managediet/api/dto/RawDto.java
@@ -10,19 +10,20 @@ import lombok.*;
 @ToString
 public class RawDto {
 
-//    @Todo 가져올 데이터 추가 해야함
     @JsonProperty("RCP_NM")
     private String recipeName;
-    @JsonProperty("INFO_ENG")       //칼로리
+    @JsonProperty("INFO_ENG")               //칼로리
     private double calorie;
-    @JsonProperty("INFO_CAR")       //탄수화물
+    @JsonProperty("INFO_CAR")               //탄수화물
     private double carbohydrate;
-    @JsonProperty("INFO_PRO")       //단백질
+    @JsonProperty("INFO_PRO")               //단백질
     private double protein;
-    @JsonProperty("INFO_FAT")       //지방
+    @JsonProperty("INFO_FAT")               //지방
     private double fat;
-    @JsonProperty("INFO_NA")       //나트륨
+    @JsonProperty("INFO_NA")                //나트륨
     private double sodium;
-    @JsonProperty("ATT_FILE_NO_MK")       //이미지(대)
+    @JsonProperty("ATT_FILE_NO_MK")         //이미지(대)
     private String image;
+    @JsonProperty("RCP_PAT2")               //레시피 타입
+    private String type;
 }

--- a/src/main/java/com/yoons/managediet/recipe/controller/RecipeRecommendController.java
+++ b/src/main/java/com/yoons/managediet/recipe/controller/RecipeRecommendController.java
@@ -1,14 +1,12 @@
 package com.yoons.managediet.recipe.controller;
 
 import com.yoons.managediet.recipe.dto.InputDto;
-import com.yoons.managediet.recipe.dto.RecipeDto;
 import com.yoons.managediet.recipe.service.RecipeRecommendService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,9 +14,8 @@ public class RecipeRecommendController {
 
     private final RecipeRecommendService recipeRecommendService;
 
-    //@Todo return 양식 통일 되도록 만들기
     @GetMapping("/recipe/search/calorie")
-    public List<RecipeDto> getRecommendRecipeList(@RequestBody InputDto inputDto) {
-        return recipeRecommendService.recommendRecipeList(inputDto.getCalorie());
+    public ResponseEntity<Object> getRecommendRecipeList(@RequestBody InputDto inputDto) {
+        return ResponseEntity.ok(recipeRecommendService.recommendRecipeList(inputDto.getCalorie()));
     }
 }

--- a/src/main/java/com/yoons/managediet/recipe/controller/RecipeRecommendController.java
+++ b/src/main/java/com/yoons/managediet/recipe/controller/RecipeRecommendController.java
@@ -1,11 +1,10 @@
 package com.yoons.managediet.recipe.controller;
 
-import com.yoons.managediet.recipe.dto.InputDto;
 import com.yoons.managediet.recipe.service.RecipeRecommendService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -14,8 +13,13 @@ public class RecipeRecommendController {
 
     private final RecipeRecommendService recipeRecommendService;
 
-    @GetMapping("/recipe/search/calorie")
-    public ResponseEntity<Object> getRecommendRecipeList(@RequestBody InputDto inputDto) {
-        return ResponseEntity.ok(recipeRecommendService.recommendRecipeList(inputDto.getCalorie()));
+    @GetMapping("/recipe/search/{calorie}")
+    public ResponseEntity<Object> getRecommendRecipeList(@PathVariable("calorie") Long calorie) {
+        return ResponseEntity.ok(recipeRecommendService.recommendRecipeList(calorie));
+    }
+
+    @GetMapping("/recipe/search/{calorie}/{typeId}")
+    public ResponseEntity<Object> getRecipeByType(@PathVariable("calorie") double calorie, @PathVariable("typeId") Long typeId) {
+        return ResponseEntity.ok(recipeRecommendService.recommendRecipeList(calorie, typeId));
     }
 }

--- a/src/main/java/com/yoons/managediet/recipe/controller/RecipeRecommendController.java
+++ b/src/main/java/com/yoons/managediet/recipe/controller/RecipeRecommendController.java
@@ -1,0 +1,24 @@
+package com.yoons.managediet.recipe.controller;
+
+import com.yoons.managediet.recipe.dto.InputDto;
+import com.yoons.managediet.recipe.dto.RecipeDto;
+import com.yoons.managediet.recipe.service.RecipeRecommendService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class RecipeRecommendController {
+
+    private final RecipeRecommendService recipeRecommendService;
+
+    //@Todo return 양식 통일 되도록 만들기
+    @GetMapping("/recipe/search/calorie")
+    public List<RecipeDto> getRecommendRecipeList(@RequestBody InputDto inputDto) {
+        return recipeRecommendService.recommendRecipeList(inputDto.getCalorie());
+    }
+}

--- a/src/main/java/com/yoons/managediet/recipe/dto/InputDto.java
+++ b/src/main/java/com/yoons/managediet/recipe/dto/InputDto.java
@@ -1,0 +1,12 @@
+package com.yoons.managediet.recipe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InputDto {
+    private double calorie;
+}

--- a/src/main/java/com/yoons/managediet/recipe/dto/OutputDto.java
+++ b/src/main/java/com/yoons/managediet/recipe/dto/OutputDto.java
@@ -1,0 +1,17 @@
+package com.yoons.managediet.recipe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class OutputDto<T> {
+    private int totalCount;
+    private List<T> values;
+}

--- a/src/main/java/com/yoons/managediet/recipe/dto/RecipeDto.java
+++ b/src/main/java/com/yoons/managediet/recipe/dto/RecipeDto.java
@@ -1,0 +1,17 @@
+package com.yoons.managediet.recipe.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class RecipeDto {
+    private Long id;
+    private String recipeName;
+    private double calorie;
+    private double carbohydrate;        //탄수화물
+    private double protein;             //단백질
+    private double fat;                 //지방
+    private double sodium;              //나트륨
+    private String image;               //이미지(대)
+}

--- a/src/main/java/com/yoons/managediet/recipe/dto/RecipeDto.java
+++ b/src/main/java/com/yoons/managediet/recipe/dto/RecipeDto.java
@@ -14,4 +14,5 @@ public class RecipeDto {
     private double fat;                 //지방
     private double sodium;              //나트륨
     private String image;               //이미지(대)
+    private String type;                //레시피 타입
 }

--- a/src/main/java/com/yoons/managediet/recipe/entity/Recipe.java
+++ b/src/main/java/com/yoons/managediet/recipe/entity/Recipe.java
@@ -1,6 +1,7 @@
 package com.yoons.managediet.recipe.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yoons.managediet.BaseTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +17,7 @@ import javax.persistence.Id;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Recipe {
+public class Recipe extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/yoons/managediet/recipe/entity/Recipe.java
+++ b/src/main/java/com/yoons/managediet/recipe/entity/Recipe.java
@@ -1,16 +1,12 @@
 package com.yoons.managediet.recipe.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.yoons.managediet.BaseTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity(name = "recipe")
 @Getter
@@ -29,4 +25,8 @@ public class Recipe extends BaseTimeEntity {
     private double fat;                 //지방
     private double sodium;              //나트륨
     private String image;            //이미지(대)
+
+    @ManyToOne
+    @JoinColumn(name = "type")
+    private RecipeType recipeType;
 }

--- a/src/main/java/com/yoons/managediet/recipe/entity/RecipeType.java
+++ b/src/main/java/com/yoons/managediet/recipe/entity/RecipeType.java
@@ -1,0 +1,26 @@
+package com.yoons.managediet.recipe.entity;
+
+import com.sun.istack.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity(name = "recipe_type")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecipeType {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @NotNull
+    private String typeName;
+}

--- a/src/main/java/com/yoons/managediet/recipe/respository/RecipeRepository.java
+++ b/src/main/java/com/yoons/managediet/recipe/respository/RecipeRepository.java
@@ -2,6 +2,7 @@ package com.yoons.managediet.recipe.respository;
 
 import com.yoons.managediet.recipe.entity.Recipe;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -9,4 +10,7 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     List<Recipe> findByRecipeNameContaining(String recipeName);
     List<Recipe> findByCalorieLessThanEqual(double calorie);
+
+    @Query(value = "select * from recipe where calorie <= ?1 and type = ?2", nativeQuery = true)
+    List<Recipe> findByCalorieAndTypeId(double calorie, Long recipeTypeId);
 }

--- a/src/main/java/com/yoons/managediet/recipe/respository/RecipeRepository.java
+++ b/src/main/java/com/yoons/managediet/recipe/respository/RecipeRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     List<Recipe> findByRecipeNameContaining(String recipeName);
+    List<Recipe> findByCalorieLessThanEqual(double calorie);
 }

--- a/src/main/java/com/yoons/managediet/recipe/respository/RecipeTypeRepository.java
+++ b/src/main/java/com/yoons/managediet/recipe/respository/RecipeTypeRepository.java
@@ -1,0 +1,11 @@
+package com.yoons.managediet.recipe.respository;
+
+import com.yoons.managediet.recipe.entity.RecipeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RecipeTypeRepository extends JpaRepository<RecipeType, Long> {
+
+    Optional<RecipeType> findByTypeName(String typeName);
+}

--- a/src/main/java/com/yoons/managediet/recipe/service/RecipeInitService.java
+++ b/src/main/java/com/yoons/managediet/recipe/service/RecipeInitService.java
@@ -1,8 +1,10 @@
 package com.yoons.managediet.recipe.service;
 
 import com.yoons.managediet.api.dto.OpenApiResponseDto;
+import com.yoons.managediet.api.dto.RawDto;
 import com.yoons.managediet.api.service.OpenApiRecipeSearchService;
 import com.yoons.managediet.recipe.entity.Recipe;
+import com.yoons.managediet.recipe.entity.RecipeType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -11,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -20,10 +23,15 @@ public class RecipeInitService {
 
     private final OpenApiRecipeSearchService openApiRecipeSearchService;
     private final RecipeRepositoryService recipeRepositoryService;
+    private final RecipeTypeRepositoryService recipeTypeRepositoryService;
 
     @Transactional
     public int initDatabase() {
         //@Todo 검증 로직 (db 데이터 사이즈 0 아니면 초기화) - delete작성
+        if (hasRecipeData()) {
+            recipeRepositoryService.deleteAll();
+        }
+
         List<Recipe> recipeList = recipeRepositoryService.saveAll(getAllRecipe());
         return recipeList.size();
     }
@@ -43,15 +51,7 @@ public class RecipeInitService {
 
             recipeList.addAll(
                     openApiResponseDto.getRawDto().stream()
-                            .map(rawDto -> Recipe.builder()
-                                    .recipeName(rawDto.getRecipeName())
-                                    .calorie(rawDto.getCalorie())
-                                    .carbohydrate(rawDto.getCarbohydrate())
-                                    .protein(rawDto.getProtein())
-                                    .fat(rawDto.getFat())
-                                    .sodium(rawDto.getSodium())
-                                    .image(rawDto.getImage())
-                                    .build())
+                            .map(rawDto -> convertToRecipe(rawDto))
                             .collect(Collectors.toList()));
             startIdx += 1000;
             endIdx += 1000;
@@ -60,5 +60,40 @@ public class RecipeInitService {
 
         log.info("[RecipeInitService getAllRecipe] total count : {}", totalCnt);
         return recipeList;
+    }
+
+    private Recipe convertToRecipe(RawDto rawDto) {
+        RecipeType recipeType = getRecipeType(rawDto.getType());
+
+        return Recipe.builder()
+                .recipeName(rawDto.getRecipeName())
+                .calorie(rawDto.getCalorie())
+                .carbohydrate(rawDto.getCarbohydrate())
+                .protein(rawDto.getProtein())
+                .fat(rawDto.getFat())
+                .sodium(rawDto.getSodium())
+                .image(rawDto.getImage())
+                .recipeType(recipeType)
+                .build();
+    }
+
+    private RecipeType getRecipeType(String typeName) {
+       if(typeName == null) {
+           return null;
+       }
+
+        return recipeTypeRepositoryService.findByTypeName(typeName)
+                .orElseGet(() -> {
+                    RecipeType savedRecipeType = recipeTypeRepositoryService.save(
+                            RecipeType.builder()
+                                    .typeName(typeName)
+                                    .build()
+                    );
+                    return savedRecipeType;
+                });
+    }
+
+    private boolean hasRecipeData() {
+        return recipeRepositoryService.count() > 0;
     }
 }

--- a/src/main/java/com/yoons/managediet/recipe/service/RecipeRecommendService.java
+++ b/src/main/java/com/yoons/managediet/recipe/service/RecipeRecommendService.java
@@ -1,0 +1,38 @@
+package com.yoons.managediet.recipe.service;
+
+import com.yoons.managediet.recipe.dto.RecipeDto;
+import com.yoons.managediet.recipe.entity.Recipe;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeRecommendService {
+
+    private final RecipeRepositoryService recipeRepositoryService;
+
+    public List<RecipeDto> recommendRecipeList(double calorie) {
+        return recipeRepositoryService.getRecipeByMaxCalorie(calorie).stream()
+                .map(recipe -> convertToRecipeDto(recipe))
+                .sorted(Comparator.comparing(RecipeDto::getCalorie).reversed())
+                .collect(Collectors.toList())
+                ;
+    }
+
+    private RecipeDto convertToRecipeDto(Recipe recipe) {
+        return RecipeDto.builder()
+                .id(recipe.getId())
+                .recipeName(recipe.getRecipeName())
+                .calorie(recipe.getCalorie())
+                .carbohydrate(recipe.getCarbohydrate())
+                .protein(recipe.getProtein())
+                .fat(recipe.getFat())
+                .sodium(recipe.getSodium())
+                .image(recipe.getImage())
+                .build();
+    }
+}

--- a/src/main/java/com/yoons/managediet/recipe/service/RecipeRecommendService.java
+++ b/src/main/java/com/yoons/managediet/recipe/service/RecipeRecommendService.java
@@ -1,5 +1,6 @@
 package com.yoons.managediet.recipe.service;
 
+import com.yoons.managediet.recipe.dto.OutputDto;
 import com.yoons.managediet.recipe.dto.RecipeDto;
 import com.yoons.managediet.recipe.entity.Recipe;
 import lombok.RequiredArgsConstructor;
@@ -15,22 +16,23 @@ public class RecipeRecommendService {
 
     private final RecipeRepositoryService recipeRepositoryService;
 
-    public List<RecipeDto> recommendRecipeList(double calorie) {
+    public OutputDto<RecipeDto> recommendRecipeList(double calorie) {
         List<Recipe> recipeList = recipeRepositoryService.getRecipeByMaxCalorie(calorie);
-        return getRecipeDtoList(recipeList);
+        return getRecommendRecipeList(recipeList);
     }
 
-    public List<RecipeDto> recommendRecipeList(double calorie, Long type) {
+    public OutputDto<RecipeDto> recommendRecipeList(double calorie, Long type) {
         List<Recipe> recipeList = recipeRepositoryService.getRecipeByMaxCalorieAndType(calorie, type);
-        return getRecipeDtoList(recipeList);
+        return getRecommendRecipeList(recipeList);
     }
 
-    private List<RecipeDto> getRecipeDtoList(List<Recipe> recipeList) {
-        return recipeList.stream()
+    private OutputDto<RecipeDto> getRecommendRecipeList(List<Recipe> recipeList) {
+        //@Todo recipeList 가 null일 때 exception 처리?
+        List<RecipeDto> recipeDtoList = recipeList.stream()
                 .map(recipe -> convertToRecipeDto(recipe))
                 .sorted(Comparator.comparing(RecipeDto::getCalorie).reversed())
-                .collect(Collectors.toList())
-        ;
+                .collect(Collectors.toList());
+        return new OutputDto<>(recipeDtoList.size(), recipeDtoList);
     }
 
     private RecipeDto convertToRecipeDto(Recipe recipe) {

--- a/src/main/java/com/yoons/managediet/recipe/service/RecipeRecommendService.java
+++ b/src/main/java/com/yoons/managediet/recipe/service/RecipeRecommendService.java
@@ -16,11 +16,21 @@ public class RecipeRecommendService {
     private final RecipeRepositoryService recipeRepositoryService;
 
     public List<RecipeDto> recommendRecipeList(double calorie) {
-        return recipeRepositoryService.getRecipeByMaxCalorie(calorie).stream()
+        List<Recipe> recipeList = recipeRepositoryService.getRecipeByMaxCalorie(calorie);
+        return getRecipeDtoList(recipeList);
+    }
+
+    public List<RecipeDto> recommendRecipeList(double calorie, Long type) {
+        List<Recipe> recipeList = recipeRepositoryService.getRecipeByMaxCalorieAndType(calorie, type);
+        return getRecipeDtoList(recipeList);
+    }
+
+    private List<RecipeDto> getRecipeDtoList(List<Recipe> recipeList) {
+        return recipeList.stream()
                 .map(recipe -> convertToRecipeDto(recipe))
                 .sorted(Comparator.comparing(RecipeDto::getCalorie).reversed())
                 .collect(Collectors.toList())
-                ;
+        ;
     }
 
     private RecipeDto convertToRecipeDto(Recipe recipe) {
@@ -33,6 +43,7 @@ public class RecipeRecommendService {
                 .fat(recipe.getFat())
                 .sodium(recipe.getSodium())
                 .image(recipe.getImage())
+                .type(recipe.getRecipeType().getTypeName())
                 .build();
     }
 }

--- a/src/main/java/com/yoons/managediet/recipe/service/RecipeRepositoryService.java
+++ b/src/main/java/com/yoons/managediet/recipe/service/RecipeRepositoryService.java
@@ -41,6 +41,11 @@ public class RecipeRepositoryService {
         return recipeRepository.findByRecipeNameContaining(recipeName);
     }
 
+    @Transactional(readOnly = true)
+    public List<Recipe> getRecipeByMaxCalorie(double calorie) {
+        return recipeRepository.findByCalorieLessThanEqual(calorie);
+    }
+
     public void deleteAll() {
         recipeRepository.deleteAll();
     }

--- a/src/main/java/com/yoons/managediet/recipe/service/RecipeRepositoryService.java
+++ b/src/main/java/com/yoons/managediet/recipe/service/RecipeRepositoryService.java
@@ -46,11 +46,20 @@ public class RecipeRepositoryService {
         return recipeRepository.findByCalorieLessThanEqual(calorie);
     }
 
+    @Transactional(readOnly = true)
+    public List<Recipe> getRecipeByMaxCalorieAndType(double calorie, Long type) {
+        return recipeRepository.findByCalorieAndTypeId(calorie, type);
+    }
+
     public void deleteAll() {
         recipeRepository.deleteAll();
     }
 
     public void deleteById(Long id) {
         recipeRepository.deleteById(id);
+    }
+
+    public Long count() {
+        return recipeRepository.count();
     }
 }

--- a/src/main/java/com/yoons/managediet/recipe/service/RecipeTypeRepositoryService.java
+++ b/src/main/java/com/yoons/managediet/recipe/service/RecipeTypeRepositoryService.java
@@ -1,0 +1,33 @@
+package com.yoons.managediet.recipe.service;
+
+import com.yoons.managediet.recipe.entity.Recipe;
+import com.yoons.managediet.recipe.entity.RecipeType;
+import com.yoons.managediet.recipe.respository.RecipeTypeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeTypeRepositoryService {
+
+    private final RecipeTypeRepository recipeTypeRepository;
+
+    public List<RecipeType> saveAll(List<RecipeType> recipeType) {
+        return recipeTypeRepository.saveAll(recipeType);
+    }
+
+    public RecipeType save(RecipeType recipeType) {
+        return recipeTypeRepository.save(recipeType);
+    }
+
+    public List<RecipeType> findAll() {
+        return recipeTypeRepository.findAll();
+    }
+
+    public Optional<RecipeType> findByTypeName(String typeName) {
+        return recipeTypeRepository.findByTypeName(typeName);
+    }
+}

--- a/src/test/groovy/com/yoons/managediet/recipe/controller/RecipeRecommendControllerTest.groovy
+++ b/src/test/groovy/com/yoons/managediet/recipe/controller/RecipeRecommendControllerTest.groovy
@@ -1,0 +1,82 @@
+package com.yoons.managediet.recipe.controller
+
+import com.yoons.managediet.recipe.dto.InputDto
+import com.yoons.managediet.recipe.dto.RecipeDto
+import com.yoons.managediet.recipe.entity.Recipe
+import com.yoons.managediet.recipe.service.RecipeRecommendService
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Specification
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class RecipeRecommendControllerTest extends Specification {
+
+    private MockMvc mockMvc
+    private RecipeRecommendService recipeRecommendService = Mock()
+    private List<Recipe> recipeList
+    private ObjectMapper objectMapper = new ObjectMapper()
+
+
+    def setup() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new RecipeRecommendController(recipeRecommendService))
+                .build()
+
+        recipeList = new ArrayList<>()
+        recipeList.addAll(
+                RecipeDto.builder()
+                        .recipeName("새우 두부 계란찜")
+                        .calorie(215)
+                        .carbohydrate(3)
+                        .protein(14)
+                        .fat(17)
+                        .sodium(99)
+                        .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00028_1.png")
+                        .build(),
+                RecipeDto.builder()
+                        .recipeName("부추 콩가루 찜")
+                        .calorie(220)
+                        .carbohydrate(20)
+                        .protein(14)
+                        .fat(9)
+                        .sodium(240)
+                        .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00029_1.png")
+                        .build(),
+                RecipeDto.builder()
+                        .recipeName("우렁된장소스 배추롤")
+                        .calorie(110.3)
+                        .carbohydrate(43)
+                        .protein(22.3)
+                        .fat(7.2)
+                        .sodium(976)
+                        .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00636_1.png")
+                        .build()
+        )
+    }
+
+    def "Get /recipe/search/calorie"() {
+        given:
+        def inputDto = new InputDto(220)
+
+        when:
+        def resultAction = mockMvc.perform(get("/recipe/search/calorie")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inputDto)))
+
+        then:
+        1 * recipeRecommendService.recommendRecipeList(argument -> {
+            assert argument == inputDto.getCalorie()
+        }) >> recipeList
+
+        resultAction.andExpect(status().isOk())
+                .andExpect(handler().handlerType(RecipeRecommendController.class))
+                .andExpect(handler().methodName("getRecommendRecipeList"))
+                .andDo(print())
+    }
+}

--- a/src/test/groovy/com/yoons/managediet/recipe/controller/RecipeRecommendControllerTest.groovy
+++ b/src/test/groovy/com/yoons/managediet/recipe/controller/RecipeRecommendControllerTest.groovy
@@ -1,10 +1,8 @@
 package com.yoons.managediet.recipe.controller
 
-import com.yoons.managediet.recipe.dto.InputDto
 import com.yoons.managediet.recipe.dto.RecipeDto
 import com.yoons.managediet.recipe.entity.Recipe
 import com.yoons.managediet.recipe.service.RecipeRecommendService
-import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper
@@ -62,16 +60,14 @@ class RecipeRecommendControllerTest extends Specification {
 
     def "Get /recipe/search/calorie"() {
         given:
-        def inputDto = new InputDto(220)
+        def calorie = 220
 
         when:
-        def resultAction = mockMvc.perform(get("/recipe/search/calorie")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(inputDto)))
+        def resultAction = mockMvc.perform(get("/recipe/search/" + calorie))
 
         then:
         1 * recipeRecommendService.recommendRecipeList(argument -> {
-            assert argument == inputDto.getCalorie()
+            assert argument == calorie
         }) >> recipeList
 
         resultAction.andExpect(status().isOk())

--- a/src/test/groovy/com/yoons/managediet/recipe/service/RecipeInitServiceTest.groovy
+++ b/src/test/groovy/com/yoons/managediet/recipe/service/RecipeInitServiceTest.groovy
@@ -1,13 +1,10 @@
 package com.yoons.managediet.recipe.service
 
-
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import spock.lang.Specification
 
 @SpringBootTest
-//@ActiveProfiles("common")
 class RecipeInitServiceTest extends Specification {
 
     @Autowired

--- a/src/test/groovy/com/yoons/managediet/recipe/service/RecipeRecommendServiceTest.groovy
+++ b/src/test/groovy/com/yoons/managediet/recipe/service/RecipeRecommendServiceTest.groovy
@@ -1,7 +1,7 @@
 package com.yoons.managediet.recipe.service
 
-
 import com.yoons.managediet.recipe.entity.Recipe
+import com.yoons.managediet.recipe.entity.RecipeType
 import spock.lang.Specification
 
 class RecipeRecommendServiceTest extends Specification {
@@ -12,6 +12,9 @@ class RecipeRecommendServiceTest extends Specification {
     private List<Recipe> recipeList
 
     def setup() {
+        def type1 = RecipeType.builder().id(1L).typeName("반찬").build()
+        def type2 = RecipeType.builder().id(2L).typeName("국").build()
+
         recipeList = new ArrayList<>()
         recipeList.addAll(
                 Recipe.builder()
@@ -22,6 +25,7 @@ class RecipeRecommendServiceTest extends Specification {
                         .fat(17)
                         .sodium(99)
                         .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00028_1.png")
+                        .recipeType(type1)
                         .build(),
                 Recipe.builder()
                         .recipeName("부추 콩가루 찜")
@@ -31,20 +35,22 @@ class RecipeRecommendServiceTest extends Specification {
                         .fat(9)
                         .sodium(240)
                         .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00029_1.png")
+                        .recipeType(type1)
                         .build(),
                 Recipe.builder()
-                        .recipeName("우렁된장소스 배추롤")
+                        .recipeName("우렁된장국")
                         .calorie(110.3)
                         .carbohydrate(43)
                         .protein(22.3)
                         .fat(7.2)
                         .sodium(976)
                         .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00636_1.png")
+                        .recipeType(type2)
                         .build()
         )
     }
 
-    def "recommendRecipeList - 결과 값이 정렬 조회되는지 확인"() {
+    def "recommendRecipeList(double calorie) - 결과 값이 정렬 조회되는지 확인"() {
         given:
         def calorie = 220.0
 

--- a/src/test/groovy/com/yoons/managediet/recipe/service/RecipeRecommendServiceTest.groovy
+++ b/src/test/groovy/com/yoons/managediet/recipe/service/RecipeRecommendServiceTest.groovy
@@ -1,0 +1,60 @@
+package com.yoons.managediet.recipe.service
+
+
+import com.yoons.managediet.recipe.entity.Recipe
+import spock.lang.Specification
+
+class RecipeRecommendServiceTest extends Specification {
+
+
+    private RecipeRepositoryService recipeRepositoryService = Mock()
+    private RecipeRecommendService recipeRecommendService = new RecipeRecommendService(recipeRepositoryService)
+    private List<Recipe> recipeList
+
+    def setup() {
+        recipeList = new ArrayList<>()
+        recipeList.addAll(
+                Recipe.builder()
+                        .recipeName("새우 두부 계란찜")
+                        .calorie(215)
+                        .carbohydrate(3)
+                        .protein(14)
+                        .fat(17)
+                        .sodium(99)
+                        .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00028_1.png")
+                        .build(),
+                Recipe.builder()
+                        .recipeName("부추 콩가루 찜")
+                        .calorie(220)
+                        .carbohydrate(20)
+                        .protein(14)
+                        .fat(9)
+                        .sodium(240)
+                        .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00029_1.png")
+                        .build(),
+                Recipe.builder()
+                        .recipeName("우렁된장소스 배추롤")
+                        .calorie(110.3)
+                        .carbohydrate(43)
+                        .protein(22.3)
+                        .fat(7.2)
+                        .sodium(976)
+                        .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00636_1.png")
+                        .build()
+        )
+    }
+
+    def "recommendRecipeList - 결과 값이 정렬 조회되는지 확인"() {
+        given:
+        def calorie = 220.0
+
+        when:
+        recipeRepositoryService.getRecipeByMaxCalorie(calorie) >> recipeList
+        def result = recipeRecommendService.recommendRecipeList(calorie)
+
+        then:
+        result.get(0).getCalorie() > result.get(1).getCalorie()
+        result.get(0).getCalorie() > result.get(2).getCalorie()
+        result.get(1).getCalorie() > result.get(2).getCalorie()
+    }
+}

--- a/src/test/groovy/com/yoons/managediet/recipe/service/RecipeRepositoryServiceTest.groovy
+++ b/src/test/groovy/com/yoons/managediet/recipe/service/RecipeRepositoryServiceTest.groovy
@@ -89,6 +89,41 @@ class RecipeRepositoryServiceTest extends Specification {
         "로제 파스타"          |       0
     }
 
+    def "getRecipeByMaxCalorie 칼로리 기준 조건 검색"() {
+        given:
+        def recipe1 = Recipe.builder()
+                .recipeName("새우 두부 계란찜")
+                .calorie(220)
+                .carbohydrate(3)
+                .protein(14)
+                .fat(17)
+                .sodium(99)
+                .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00028_1.png")
+                .build()
+        def recipe2 = Recipe.builder()
+                .recipeName("부추 콩가루 찜")
+                .calorie(215)
+                .carbohydrate(20)
+                .protein(14)
+                .fat(9)
+                .sodium(240)
+                .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00029_1.png")
+                .build()
+        recipeRepositoryService.saveAll(Arrays.asList(recipe1, recipe2))
+
+        when:
+        def result = recipeRepositoryService.getRecipeByMaxCalorie(calorie)
+
+        then:
+        result.size() == expectedResult
+
+        where:
+        calorie         |       expectedResult
+        210             |       0
+        218             |       1
+        220             |       2
+    }
+
     def "deleteAll test"() {
         given:
         def recipe1 = Recipe.builder()

--- a/src/test/groovy/com/yoons/managediet/recipe/service/RecipeRepositoryServiceTest.groovy
+++ b/src/test/groovy/com/yoons/managediet/recipe/service/RecipeRepositoryServiceTest.groovy
@@ -1,6 +1,7 @@
 package com.yoons.managediet.recipe.service
 
 import com.yoons.managediet.recipe.entity.Recipe
+import com.yoons.managediet.recipe.entity.RecipeType
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import spock.lang.Specification
@@ -10,6 +11,8 @@ class RecipeRepositoryServiceTest extends Specification {
 
     @Autowired
     RecipeRepositoryService recipeRepositoryService
+    @Autowired
+    RecipeTypeRepositoryService recipeTypeRepositoryService
 
     def setup() {
         recipeRepositoryService.deleteAll()
@@ -122,6 +125,62 @@ class RecipeRepositoryServiceTest extends Specification {
         210             |       0
         218             |       1
         220             |       2
+    }
+
+    def "getRecipeByMaxCalorieAndType 칼로리와 타입 조건 검색"() {
+        given:
+        List<RecipeType> recipeTypeList = new ArrayList<>()
+        recipeTypeList.addAll(
+                RecipeType.builder().typeName("반찬").build(),
+                RecipeType.builder().typeName("국").build()
+        )
+
+        recipeTypeRepositoryService.saveAll(recipeTypeList)
+        def savedRecipeTypeList = recipeTypeRepositoryService.findAll()
+
+        def recipe1 = Recipe.builder()
+                .recipeName("새우 두부 계란찜")
+                .calorie(220)
+                .carbohydrate(3)
+                .protein(14)
+                .fat(17)
+                .sodium(99)
+                .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00028_1.png")
+                .recipeType(savedRecipeTypeList.get(0))
+                .build()
+        def recipe2 = Recipe.builder()
+                .recipeName("부추 콩가루 찜")
+                .calorie(215)
+                .carbohydrate(20)
+                .protein(14)
+                .fat(9)
+                .sodium(240)
+                .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00029_1.png")
+                .recipeType(savedRecipeTypeList.get(0))
+                .build()
+        def recipe3 = Recipe.builder()
+                .recipeName("우렁된장국")
+                .calorie(110.3)
+                .carbohydrate(43)
+                .protein(22.3)
+                .fat(7.2)
+                .sodium(976)
+                .image("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00636_1.png")
+                .recipeType(savedRecipeTypeList.get(1))
+                .build()
+        recipeRepositoryService.saveAll(Arrays.asList(recipe1, recipe2, recipe3))
+
+        when:
+        def result = recipeRepositoryService.getRecipeByMaxCalorieAndType(calorie, typeId)
+
+        then:
+        result.size() == expectedResult
+
+        where:
+        calorie         |      typeId     |    expectedResult
+        210             |      2L         |    1
+        218             |      1L         |    1
+        220             |      1L         |    2
     }
 
     def "deleteAll test"() {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,5 +16,5 @@ spring:
     url: jdbc:tc:mysql:8.0.33:///
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true


### PR DESCRIPTION
## 관련 이슈
* https://github.com/buchonsi/Manage-diet/issues/4

## 추가 사항
* 목표 칼로리 이하의 레시피 조회
  * 칼로리를 입력 받고, 해당 칼로리 값 이하의 레시피를 조회하는 방식으로 동작
* 조회 조건 추가 (타입을 기준으로 조회)
  * 칼로리와 타입의 아이디를 입력 받고, 칼로리 값 이하, 해당 타입을 조히하여 레시피를 가져옴
 
## 주의 사항
* 사실상 칼로리 값 이하의 레시피 리스트를 역순으로 정렬하여 응답하는 방식인데 추천 서비스라기에는  조금 부족하다고 생각.
  * (개선방법1) 입력받은 칼로리 기준으로 일정 범위의 레시피만 가져오도록 변경 >> 조회 속도 어떨지 고민필요.
  * (개선방법2) 리미트를 사용해서 개수를 지정하여 레시피 응답.
* 조회 조건을 추가할 때 현재는 정적으로 타입에 해당하는 조건만 추가하도록 되어있는데 동적으로 변경하도록 개선필요